### PR TITLE
Fix deprecation warnings

### DIFF
--- a/tasks/create-virtual-user.yml
+++ b/tasks/create-virtual-user.yml
@@ -15,15 +15,15 @@
 
 - name: "User {{ user.name }}: Create virtual user"
   shell: "(echo {{ user.password }}; echo {{ user.password }}) | pure-pw useradd {{ user.name }} -u {{ user.uid | default(pureftpd_virtual_users_user) }} -g {{ user.gid | default(pureftpd_virtual_users_group) }} -d {{ user.homedir }} -n {{ user.quota_files | default('\"\"') }} -N {{ user.quota_size | default('\"\"') }} -t {{ user.bandwidth_dl | default('\"\"') }} -T {{ user.bandwidth_ul | default('\"\"') }} -q {{ user.ratio_ul | default('\"\"') }} -Q {{ user.ratio_dl | default('\"\"') }}"
-  when: pureftpd_virtual_user_exists | failed
+  when: pureftpd_virtual_user_exists is failed
   notify: reload Pure-FTPd users
 
 - name: "User {{ user.name }}: Update virtual user"
   command: "pure-pw usermod {{ user.name }} -u {{ user.uid | default(pureftpd_virtual_users_user) }} -g {{ user.gid | default(pureftpd_virtual_users_group) }} -d {{ user.homedir }} -n {{ user.quota_files | default('\"\"') }} -N {{ user.quota_size | default('\"\"') }} -t {{ user.bandwidth_dl | default('\"\"') }} -T {{ user.bandwidth_ul | default('\"\"') }} -q {{ user.ratio_ul | default('\"\"') }} -Q {{ user.ratio_dl | default('\"\"') }}"
-  when: pureftpd_virtual_user_exists | success
+  when: pureftpd_virtual_user_exists is success
   notify: reload Pure-FTPd users
 
 - name: "User {{ user.name }}: Update virtual user password"
   shell: "(echo {{ user.password }}; echo {{ user.password }}) | pure-pw passwd {{ user.name }}"
-  when: pureftpd_virtual_user_exists | success
+  when: pureftpd_virtual_user_exists is success
   notify: reload Pure-FTPd users

--- a/tasks/remove-virtual-user.yml
+++ b/tasks/remove-virtual-user.yml
@@ -7,5 +7,5 @@
 
 - name: "User {{ user.name }}: Remove virtual user"
   shell: "pure-pw userdel {{ user.name }}"
-  when: pureftpd_virtual_user_exists | success
+  when: pureftpd_virtual_user_exists is success
   notify: reload Pure-FTPd users


### PR DESCRIPTION
I'm getting these warnings in ansible 2.5:

> [DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|failed` instead use `result is failed`. This feature will be removed in version 2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in 
ansible.cfg.

This PR replaces all instances of this construct with the suggested alternative.